### PR TITLE
Mark SDK Assets as Private to Prevent Publishing

### DIFF
--- a/src/Templates.PSCore/content/ps-core-module/PSModule.csproj
+++ b/src/Templates.PSCore/content/ps-core-module/PSModule.csproj
@@ -7,6 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.PowerShell.SDK" Version="6.0.0"/>
+    <PackageReference Include="Microsoft.PowerShell.SDK" Version="6.0.0">
+        <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR Marks the Microsoft.PowerShell.SDK reference in the template as private. This prevents the SDK from being published with the module code. The SDK should not ship with the module as it is essentially a duplicate of everything that ships with PowerShell Core.

Before:

![2018042101-before](https://user-images.githubusercontent.com/6509955/39090175-58d402ae-459d-11e8-90d1-0e56d953eadc.PNG)

After:

![2018042101-after](https://user-images.githubusercontent.com/6509955/39090177-63ee4532-459d-11e8-9b2e-286069885153.PNG)
